### PR TITLE
New attempt at fetching submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ IF(COMMAND CMAKE_POLICY)
 	ENDIF()
 ENDIF(COMMAND CMAKE_POLICY)
 
+INCLUDE(CheckSubmodules)
 INCLUDE(AddFileDependencies)
 INCLUDE(CheckIncludeFiles)
 INCLUDE(FindPkgConfig)

--- a/cmake/modules/CheckSubmodules.cmake
+++ b/cmake/modules/CheckSubmodules.cmake
@@ -1,0 +1,76 @@
+# Utility for validating and, if needed, cloning all submodules
+#
+# Looks for a .gitmodules in the root project folder
+# Loops over all modules looking well-known configure/build scripts
+#
+# Usage:
+#       INCLUDE(CheckSubmodules)
+#
+# Options:
+#       SET(SKIP_SUBMODULES "foo;bar")
+#
+# Or via command line:       
+#       cmake -DSKIP_SUBMODULES=foo;bar
+#
+# Copyright (c) 2017, Tres Finocchiaro, <tres.finocchiaro@gmail.com>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+# Files which confirm a successful clone
+SET(VALID_CRUMBS "CMakeLists.txt;Makefile.in;Makefile.am;configure.ac;configure.py;autogen.sh")
+
+MESSAGE("\nValidating submodules...")
+FILE(READ "${CMAKE_SOURCE_DIR}/.gitmodules" SUBMODULE_DATA)
+
+# Assume alpha-numeric paths
+STRING(REGEX MATCHALL "path = [0-9A-Za-z/]+" SUBMODULE_LIST ${SUBMODULE_DATA})
+FOREACH(_part ${SUBMODULE_LIST})
+	STRING(REPLACE "path = " "" SUBMODULE_PATH ${_part})
+
+	# Remove submodules from validation as specified in -DSKIP_SUBMODULES=foo;bar
+	SET(SKIP false)
+	IF(SKIP_SUBMODULES)
+		FOREACH(_skip ${SKIP_SUBMODULES})
+			IF(${SUBMODULE_PATH} MATCHES ${_skip})
+				MESSAGE("-- Skipping ${SUBMODULE_PATH} matches \"${_skip}\"")
+				SET(SKIP true)
+			ENDIF()
+		ENDFOREACH()
+	ENDIF()
+	LIST(REMOVE_ITEM SUBMODULE_LIST ${_part})
+	IF(NOT SKIP)
+		LIST(APPEND SUBMODULE_LIST ${SUBMODULE_PATH})
+	ENDIF()
+ENDFOREACH()
+
+LIST(SORT SUBMODULE_LIST)
+
+# Attempt to do lazy clone
+FOREACH(_submodule ${SUBMODULE_LIST})
+	STRING(REPLACE "/" ";" PATH_PARTS ${_submodule})
+	LIST(REVERSE PATH_PARTS)
+	LIST(GET PATH_PARTS 0 SUBMODULE_NAME)
+
+	MESSAGE("-- Checking ${SUBMODULE_NAME}...")
+	SET(CRUMB_FOUND false)
+	FOREACH(_crumb ${VALID_CRUMBS})
+		IF(EXISTS "${CMAKE_SOURCE_DIR}/${_submodule}/${_crumb}")
+			SET(CRUMB_FOUND true)
+			MESSAGE("--   Found ${_submodule}/${_crumb}")
+		ENDIF()
+	ENDFOREACH()
+	IF(NOT CRUMB_FOUND)
+		FIND_PACKAGE(Git REQUIRED)
+		MESSAGE("--   Missing ${_submodule}")
+		EXECUTE_PROCESS(
+			COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive ${CMAKE_SOURCE_DIR}/${_submodule}
+			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+			ERROR_VARIABLE GIT_STDERR
+		)
+		IF(GIT_STDERR)
+			MESSAGE(FATAL_ERROR ${GIT_STDERR})
+		ENDIF()
+	ENDIF()
+ENDFOREACH()
+MESSAGE("-- Done validating submodules.\n")


### PR DESCRIPTION
The previous attempt required each submodule to specify it's own breadcrumb file, but after using it for a few, I realized it adds unnecessary logic to every `CMakeLists.txt` which contains a submodule.

The new technique parses the `.gitmodules` file and clones each submodule by path, unless the module was specified in `SKIP_SUBMODULES`.

Usage:

```cmake
# Clones everything except plugins/LadspaEffect/swh/swh
SET(SKIP_SUBMODULES swh)
INCLUDE(CheckSubmodules)
```
Or via CLI:

```bash
# Clones everything except zynaddsubfx and rpmalloc
cmake -DSKIP_SUBMODULES=zynaddsubfx;rpmalloc
```

* Eventually we may want to bind the `ADD_SUBDIRECTORY(...)` to be cognizant of the submodule status, but that is out of scope for this PR.
* Eventually we may want to check if a submodule is out of date and warn the user.  This may happen if a branch hasn't recently been pulled, or if switching to a branch with a different submodule commit.  This should be rare and is out of scope for this PR.

Once tested and merged to `master`, this PR should be safe to cherry-pick back to `stable-1.2`.

> (Editorial) 
>
> Submodules are annoying.
> 
> As the author of a few submodule PRs, I'm continuously forgetting `--recurse` or I'm switching branches without re-running `git submodule update --init --recursive`.  Sometimes cmake puts files in the directories and makes them non-clean so I have to clean them before running the commmands again.
> 
> To make things worse, I still haven't memorized if it's `init --update` or `update --init` (it's the latter, of course).
> 
> If I'm this frustrated after a week of working on submodules, newcomers will have an even harder time.
> 
> That said, submodules are great!  They allow us to pull directly from upstream without the mess of cluttering our codebase and risk not submitting patches to the right area.
> 
> So we have to live with them.  This is my second attempt to make that happen.  :) -Tres